### PR TITLE
fix(api): réserve POST /homepage/warm au trafic service-à-service (se…

### DIFF
--- a/apps/api/src/modules/homepage/homepage.controller.ts
+++ b/apps/api/src/modules/homepage/homepage.controller.ts
@@ -4,7 +4,7 @@
 // =============================================================================
 
 import { FastifyPluginAsync } from 'fastify';
-import { isInternalRequest } from '../../utils/internal-auth';
+import { isStrictlyInternalRequest } from '../../utils/internal-auth';
 
 // Cache 27h — survit au sync (CRON 5h, durée max ~2h) + marge
 // Le cache est renouvelé activement par l'ingestion après chaque sync
@@ -272,10 +272,14 @@ export const homepageRoutes: FastifyPluginAsync = async (fastify) => {
       description: 'Appelé par le service d\'ingestion après la synchronisation quotidienne',
     },
     handler: async (request, reply) => {
-      // Protégé par le secret interne partagé entre l'API et le scheduler.
-      // C'est ce même secret qui identifie le frontend (voir utils/internal-auth.ts),
-      // avec une comparaison en temps constant.
-      if (!isInternalRequest(request)) {
+      // Réservé au trafic service-à-service : le secret interne SEUL ne protège
+      // rien ici. Le proxy du frontend le pose sur tout ce qu'il relaie, donc
+      // s'en contenter rendait cet endpoint appelable par n'importe quel
+      // visiteur — un `fetch` en boucle vidait `homepage:data` et forçait la
+      // réagrégation que le TTL de 27 h existe justement pour éviter.
+      // `isStrictlyInternalRequest` exige en plus l'absence de `x-clair-client-ip`,
+      // que le scheduler d'ingestion ne pose pas (services/ingestion/src/cli.ts).
+      if (!isStrictlyInternalRequest(request)) {
         fastify.log.warn(
           { ip: request.ip, ua: request.headers['user-agent'] || 'none' },
           'Cache warm 403',

--- a/apps/api/src/utils/internal-auth.test.ts
+++ b/apps/api/src/utils/internal-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import type { FastifyRequest } from 'fastify';
 import {
   isInternalRequest,
+  isStrictlyInternalRequest,
   hasInternalSecret,
   getForwardedClientIp,
   INTERNAL_HEADER,
@@ -113,6 +114,49 @@ describe('getForwardedClientIp', () => {
     process.env.CLAIR_INTERNAL_SECRET = 'secret-interne';
     const r = req({ [INTERNAL_HEADER]: 'secret-interne', [CLIENT_IP_HEADER]: '   ' });
     expect(getForwardedClientIp(r)).toBeNull();
+  });
+});
+
+describe('isStrictlyInternalRequest', () => {
+  it('accepte le scheduler d\'ingestion : secret seul, sans IP relayée', () => {
+    process.env.CLAIR_INTERNAL_SECRET = 'secret-interne';
+    // Exactement les en-têtes posés par services/ingestion/src/cli.ts.
+    const r = req({ [INTERNAL_HEADER]: 'secret-interne', 'user-agent': 'clair-ingestion/1.0' });
+    expect(isStrictlyInternalRequest(r)).toBe(true);
+  });
+
+  it('refuse le trafic relayé par le proxy, secret valide compris', () => {
+    process.env.CLAIR_INTERNAL_SECRET = 'secret-interne';
+    // Le proxy pose le secret sur tout ce qu'il transmet : c'est le cas qui
+    // rendait POST /homepage/warm déclenchable depuis n'importe quelle page.
+    const r = req({
+      [INTERNAL_HEADER]: 'secret-interne',
+      [CLIENT_IP_HEADER]: '203.0.113.7',
+      'user-agent': 'CLAIR-Web-Proxy/1.0',
+    });
+    expect(isInternalRequest(r)).toBe(true);
+    expect(isStrictlyInternalRequest(r)).toBe(false);
+  });
+
+  it('refuse une requête sans secret, IP relayée forgée ou non', () => {
+    process.env.CLAIR_INTERNAL_SECRET = 'secret-interne';
+    expect(isStrictlyInternalRequest(req({}))).toBe(false);
+    expect(isStrictlyInternalRequest(req({ [CLIENT_IP_HEADER]: '203.0.113.7' }))).toBe(false);
+    expect(isStrictlyInternalRequest(req({ [INTERNAL_HEADER]: 'mauvais' }))).toBe(false);
+  });
+
+  it('refuse quand aucun secret n\'est configuré', () => {
+    expect(isStrictlyInternalRequest(req({ [INTERNAL_HEADER]: 'peu-importe' }))).toBe(false);
+  });
+
+  it('traite une IP relayée vide comme absente, sans ouvrir de contournement', () => {
+    process.env.CLAIR_INTERNAL_SECRET = 'secret-interne';
+    // Le proxy ne peut pas produire ce cas (clientIp() retombe sur 127.0.0.1),
+    // mais un appel direct le pourrait : il reste alors du service-à-service,
+    // authentifié par le secret. Rien de plus permissif qu'une requête sans
+    // l'en-tête du tout.
+    const r = req({ [INTERNAL_HEADER]: 'secret-interne', [CLIENT_IP_HEADER]: '   ' });
+    expect(isStrictlyInternalRequest(r)).toBe(true);
   });
 });
 

--- a/apps/api/src/utils/internal-auth.ts
+++ b/apps/api/src/utils/internal-auth.ts
@@ -81,6 +81,29 @@ export function hasInternalSecret(): boolean {
 }
 
 /**
+ * La requête vient-elle d'un service interne parlant à l'API en direct, sans
+ * navigateur au bout de la chaîne ?
+ *
+ * `isInternalRequest()` seul ne suffit PAS à protéger un endpoint : le proxy du
+ * frontend pose le secret sur tout ce qu'il relaie, y compris ce qu'un visiteur
+ * déclenche depuis sa page. Le secret prouve « cette requête a traversé un de
+ * nos serveurs », jamais « un humain n'est à l'origine de cette requête ».
+ *
+ * La différence se lit sur `x-clair-client-ip` : le proxy le pose toujours (il
+ * en a besoin pour le rate-limit), le scheduler d'ingestion jamais. Son absence
+ * est donc la signature du trafic service-à-service.
+ *
+ * ⚠️ C'est CE contrôle, et non `isInternalRequest()`, que doit utiliser tout
+ * endpoint à effet de bord réservé à nos machines. Avec le contrôle laxiste,
+ * `fetch('/api/v1/…', { method: 'POST' })` depuis n'importe quelle page suffit
+ * à l'atteindre — et comme un POST sans `content-type` custom est une « simple
+ * request » CORS, même un site tiers peut le déclencher chez ses visiteurs.
+ */
+export function isStrictlyInternalRequest(request: FastifyRequest): boolean {
+  return isInternalRequest(request) && getForwardedClientIp(request) === null;
+}
+
+/**
  * IP du visiteur relayée par le proxy du frontend, ou `null`.
  *
  * Renvoie `null` si la requête n'est pas authentifiée comme interne : l'en-tête

--- a/apps/web/app/api/v1/[...path]/route.ts
+++ b/apps/web/app/api/v1/[...path]/route.ts
@@ -56,6 +56,27 @@ const EDGE_STALE_SECONDS = 86_400;
 /** Méthodes sans effet de bord, seules candidates au cache partagé. */
 const SAFE_METHODS = new Set(['GET', 'HEAD']);
 
+/**
+ * Chemins réservés au trafic service-à-service, que ce proxy ne doit jamais
+ * relayer.
+ *
+ * Ce handler pose le secret interne sur TOUT ce qu'il transmet — c'est sa raison
+ * d'être. Un endpoint qui se contente de vérifier ce secret devient donc, sans
+ * cette liste, appelable depuis n'importe quelle page web. L'API refait le
+ * contrôle de son côté (`isStrictlyInternalRequest`) et c'est elle qui fait
+ * autorité ; cette liste évite simplement qu'une requête forgée serve à sonder
+ * un chemin interne depuis clair.vote.
+ *
+ * Le seul appelant légitime de ces chemins est le scheduler d'ingestion, qui
+ * joint l'API par le réseau privé Railway et ne passe donc jamais par ici.
+ *
+ * ⚠️ On ne peut PAS généraliser en refusant simplement le secret sur les
+ * méthodes mutantes : sans lui, l'API ne voit plus `x-clair-client-ip` et compte
+ * tous les visiteurs sur l'IP de cette fonction. Un futur POST navigateur
+ * (connexion) partagerait un seul quota et pourrait faire bannir l'IP Vercel.
+ */
+const INTERNAL_ONLY_PATHS = new Set(['homepage/warm']);
+
 /** En-têtes de réponse à ne jamais relayer tels quels. */
 const STRIPPED_RESPONSE_HEADERS = new Set([
   // `fetch` décompresse déjà le corps : relayer `content-encoding: gzip` sur des
@@ -109,7 +130,25 @@ function clientIp(request: NextRequest): string {
   return forwarded?.split(',')[0]?.trim() || '127.0.0.1';
 }
 
+/**
+ * Normalise avant comparaison : Next décode déjà les segments, on retire les
+ * segments vides (`homepage//warm`) et la casse pour qu'aucune de ces variantes
+ * ne passe à côté de la liste.
+ */
+function isInternalOnly(path: string[]): boolean {
+  return INTERNAL_ONLY_PATHS.has(path.filter(Boolean).join('/').toLowerCase());
+}
+
 async function proxy(request: NextRequest, path: string[]): Promise<Response> {
+  // 404 plutôt que 403 : depuis l'extérieur ce chemin n'existe pas, et une
+  // réponse distincte confirmerait qu'il y a quelque chose à trouver.
+  if (isInternalOnly(path)) {
+    return NextResponse.json(
+      { error: 'Not Found', code: 'NOT_FOUND' },
+      { status: 404, headers: { 'Cache-Control': 'private, no-store' } },
+    );
+  }
+
   const secret = process.env.CLAIR_INTERNAL_SECRET?.trim();
   const target = `${API_URL}/api/v1/${path.join('/')}${request.nextUrl.search}`;
 


### PR DESCRIPTION
…cret seul, sans x-clair-client-ip)